### PR TITLE
remove lazy-build from v attribute in Net/BitTorrent/Protocol/BEP05/Node.pm

### DIFF
--- a/lib/Net/BitTorrent/Protocol/BEP05/Node.pm
+++ b/lib/Net/BitTorrent/Protocol/BEP05/Node.pm
@@ -38,7 +38,7 @@ package Net::BitTorrent::Protocol::BEP05::Node;
                        default => sub { {} }
             );
     }
-    has 'v' => (isa => 'Str', is => 'ro', writer => '_v', lazy_build => 1,);
+    has 'v' => (isa => 'Str', is => 'ro', writer => '_v', predicate => 'has_v');
     has 'bucket' => (isa       => 'Net::BitTorrent::Protocol::BEP05::Bucket',
                      is        => 'ro',
                      writer    => 'assign_bucket',


### PR DESCRIPTION
Net/BitTorrent/Protocol/BEP05/Node::v attribute was marked "lazy_build", but there was no build_v; and needed predicate.
